### PR TITLE
Enable REST POST endpoints

### DIFF
--- a/proto/ardapoc/arda/tx.proto
+++ b/proto/ardapoc/arda/tx.proto
@@ -7,6 +7,7 @@ import "cosmos/msg/v1/msg.proto";
 import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 import "ardapoc/arda/params.proto";
+import "google/api/annotations.proto";
 
 option go_package = "github.com/ardaglobal/arda-poc/x/arda/types";
 
@@ -17,7 +18,12 @@ service Msg {
   // UpdateParams defines a (governance) operation for updating the module
   // parameters. The authority defaults to the x/gov module account.
   rpc UpdateParams (MsgUpdateParams) returns (MsgUpdateParamsResponse);
-  rpc SubmitHash   (MsgSubmitHash  ) returns (MsgSubmitHashResponse  );
+  rpc SubmitHash   (MsgSubmitHash  ) returns (MsgSubmitHashResponse  ) {
+    option (google.api.http) = {
+      post: "/cosmonaut/arda/arda/submissions"
+      body: "*"
+    };
+  }
 }
 // MsgUpdateParams is the Msg/UpdateParams request type.
 message MsgUpdateParams {

--- a/proto/ardapoc/property/tx.proto
+++ b/proto/ardapoc/property/tx.proto
@@ -7,6 +7,7 @@ import "cosmos/msg/v1/msg.proto";
 import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 import "ardapoc/property/params.proto";
+import "google/api/annotations.proto";
 
 option go_package = "github.com/ardaglobal/arda-poc/x/property/types";
 
@@ -17,8 +18,18 @@ service Msg {
   // UpdateParams defines a (governance) operation for updating the module
   // parameters. The authority defaults to the x/gov module account.
   rpc UpdateParams     (MsgUpdateParams    ) returns (MsgUpdateParamsResponse    );
-  rpc RegisterProperty (MsgRegisterProperty) returns (MsgRegisterPropertyResponse);
-  rpc TransferShares   (MsgTransferShares  ) returns (MsgTransferSharesResponse  );
+  rpc RegisterProperty (MsgRegisterProperty) returns (MsgRegisterPropertyResponse) {
+    option (google.api.http) = {
+      post: "/cosmonaut/arda/property/properties"
+      body: "*"
+    };
+  }
+  rpc TransferShares   (MsgTransferShares  ) returns (MsgTransferSharesResponse  ) {
+    option (google.api.http) = {
+      post: "/cosmonaut/arda/property/shares/transfers"
+      body: "*"
+    };
+  }
 }
 // MsgUpdateParams is the Msg/UpdateParams request type.
 message MsgUpdateParams {

--- a/readme.md
+++ b/readme.md
@@ -57,12 +57,15 @@ The REST API endpoints exposed by the modules under `x/` are derived from the gR
 - `GET /arda/property/params` - query property module parameters
 - `GET /cosmonaut/arda/property/properties` - list all registered properties
 - `GET /cosmonaut/arda/property/properties/{index}` - get a property by index
+- `POST /cosmonaut/arda/property/properties` - register a property
+- `POST /cosmonaut/arda/property/shares/transfers` - transfer property shares
 
 ### x/arda
 
 - `GET /arda/arda/params` - query arda module parameters
 - `GET /cosmonaut/arda/arda/submissions` - list all submissions
 - `GET /cosmonaut/arda/arda/submissions/{id}` - get a submission by id
+- `POST /cosmonaut/arda/arda/submissions` - submit a hash
 
 ## Release
 To release a new version of your blockchain, create and push a new tag with `v` prefix. A new draft release with the configured targets will be created.


### PR DESCRIPTION
## Summary
- allow REST POST routes for key tx actions
- document POST endpoints in README

## Testing
- `go list ./...` *(fails: no route to host)*