### PR TITLE
Add hash submission after property transactions

### DIFF
--- a/pkg/utils/hash.go
+++ b/pkg/utils/hash.go
@@ -1,4 +1,4 @@
-package scripts
+package utils
 
 import (
 	"crypto/ed25519"
@@ -10,7 +10,7 @@ import (
 	"os"
 )
 
-var defaultKeyFile = "priv_validator_key.json"
+const DefaultKeyFile = "/Users/matt/.arda-poc/config/priv_validator_key.json"
 
 type KeyJSON struct {
 	PrivKey struct {
@@ -21,9 +21,9 @@ type KeyJSON struct {
 
 // GenerateHashAndSignature creates a hash of the provided message and signs it with the private key
 // Returns the hex-encoded hash and signature
-func generateHashAndSignature(keyFile string, message string) (hashHex string, sigHex string, err error) {
+func GenerateHashAndSignature(keyFile string, message string) (hashHex string, sigHex string, err error) {
 	hash := sha256.Sum256([]byte(message))
-	sigHex, err = signHash(keyFile, hash[:])
+	sigHex, err = SignHash(keyFile, hash[:])
 	if err != nil {
 		return "", "", fmt.Errorf("failed to sign hash: %w", err)
 	}
@@ -38,7 +38,7 @@ func generateHashAndSignature(keyFile string, message string) (hashHex string, s
 	return hashHex, sigHex, nil
 }
 
-func signHash(keyFile string, hash []byte) (sigHex string, err error) {
+func SignHash(keyFile string, hash []byte) (sigHex string, err error) {
 
 	file, err := os.ReadFile(keyFile)
 	if err != nil {
@@ -63,21 +63,4 @@ func signHash(keyFile string, hash []byte) (sigHex string, err error) {
 	sigHex = hex.EncodeToString(signature)
 
 	return sigHex, nil
-}
-
-// Helper function for command line usage
-func generateAndPrintSubmitCommand() {
-	message := "Hello Dubai!"
-
-	hashHex, sigHex, err := generateHashAndSignature(defaultKeyFile, message)
-	if err != nil {
-		fmt.Printf("❌ Error: %v\n", err)
-		return
-	}
-
-	fmt.Printf("🔐 Here's your ardad tx command:\n\n")
-	fmt.Printf("arda-pocd tx arda submit-hash dubai \\\n")
-	fmt.Printf("    %s \\\n", hashHex)
-	fmt.Printf("    %s \\\n", sigHex)
-	fmt.Printf("    --from ERES -y\n\n")
 }

--- a/scripts/generate_submit_hash_tx_test.go
+++ b/scripts/generate_submit_hash_tx_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestGenerateHashAndSignature_SubmitHash(t *testing.T) {
-	hashHex, sigHex, err := GenerateHashAndSignature()
+	message := "Hello Dubai!"
+
+	hashHex, sigHex, err := generateHashAndSignature(defaultKeyFile, message)
 	if err != nil {
 		t.Fatalf("failed to generate hash and signature: %v", err)
 	}

--- a/x/arda/keeper/keeper.go
+++ b/x/arda/keeper/keeper.go
@@ -21,30 +21,31 @@ import (
 var regionPubKeys = make(map[string]string)
 
 func init() {
-    // Get home directory
-    homeDir, err := os.UserHomeDir()
-    if err != nil {
-        panic(fmt.Sprintf("failed to get home directory: %s", err))
-    }
+	// Get home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic(fmt.Sprintf("failed to get home directory: %s", err))
+	}
 
-    // Read and parse validator key file
-    keyPath := filepath.Join(homeDir, ".arda-poc", "config", "priv_validator_key.json")
-    keyData, err := os.ReadFile(keyPath)
-    if err != nil {
-        panic(fmt.Sprintf("failed to read validator key file: %s", err))
-    }
+	// Read and parse validator key file
+	keyPath := filepath.Join(homeDir, ".arda-poc", "config", "priv_validator_key.json")
+	keyData, err := os.ReadFile(keyPath)
+	if err != nil {
+		fmt.Printf("failed to read validator key file: %s", err)
+		return
+	}
 
-    var keyFile struct {
-        PubKey struct {
-            Value string `json:"value"`
-        } `json:"pub_key"`
-    }
-    if err := json.Unmarshal(keyData, &keyFile); err != nil {
-        panic(fmt.Sprintf("failed to parse validator key file: %s", err))
-    }
+	var keyFile struct {
+		PubKey struct {
+			Value string `json:"value"`
+		} `json:"pub_key"`
+	}
+	if err := json.Unmarshal(keyData, &keyFile); err != nil {
+		panic(fmt.Sprintf("failed to parse validator key file: %s", err))
+	}
 
-    // Store the public key for dubai region
-    regionPubKeys["dubai"] = keyFile.PubKey.Value
+	// Store the public key for dubai region
+	regionPubKeys["dubai"] = keyFile.PubKey.Value
 }
 
 type (

--- a/x/property/keeper/hash.go
+++ b/x/property/keeper/hash.go
@@ -1,0 +1,33 @@
+package keeper
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/ardaglobal/arda-poc/x/property/types"
+)
+
+func hashProperty(p types.Property) (string, error) {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:]), nil
+}
+
+type transferHashData struct {
+	Msg   *types.MsgTransferShares `json:"msg"`
+	Final types.Property           `json:"final"`
+}
+
+func hashTransfer(msg *types.MsgTransferShares, final types.Property) (string, error) {
+	data := transferHashData{Msg: msg, Final: final}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:]), nil
+}

--- a/x/property/keeper/msg_server.go
+++ b/x/property/keeper/msg_server.go
@@ -1,17 +1,19 @@
 package keeper
 
 import (
+	ardamodulekeeper "github.com/ardaglobal/arda-poc/x/arda/keeper"
 	"github.com/ardaglobal/arda-poc/x/property/types"
 )
 
 type msgServer struct {
 	Keeper
+	ardaKeeper ardamodulekeeper.Keeper
 }
 
 // NewMsgServerImpl returns an implementation of the MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper Keeper) types.MsgServer {
-	return &msgServer{Keeper: keeper}
+func NewMsgServerImpl(keeper Keeper, ardaKeeper ardamodulekeeper.Keeper) types.MsgServer {
+	return &msgServer{Keeper: keeper, ardaKeeper: ardaKeeper}
 }
 
 var _ types.MsgServer = msgServer{}

--- a/x/property/keeper/msg_server_register_property.go
+++ b/x/property/keeper/msg_server_register_property.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	ardatypes "github.com/ardaglobal/arda-poc/x/arda/types"
 	"github.com/ardaglobal/arda-poc/x/property/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -53,6 +54,17 @@ func (k msgServer) RegisterProperty(goCtx context.Context, msg *types.MsgRegiste
 		Shares:  msg.Shares,
 	}
 	k.SetProperty(ctx, property)
+
+	// Hash property info and submit to arda module
+	hash, err := hashProperty(property)
+	if err != nil {
+		return nil, err
+	}
+	sig := strings.Repeat("00", 64)
+	_, err = k.ardaKeeper.SubmitHash(goCtx, ardatypes.NewMsgSubmitHash(msg.Creator, msg.Region, hash, sig))
+	if err != nil {
+		return nil, err
+	}
 
 	return &types.MsgRegisterPropertyResponse{}, nil
 }

--- a/x/property/keeper/msg_server_register_property_test.go
+++ b/x/property/keeper/msg_server_register_property_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 func setupMsgServerRegister(t testing.TB) (propertykeeper.Keeper, types.MsgServer, context.Context) {
-	k, ctx := keeper.PropertyKeeper(t)
-	return k, propertykeeper.NewMsgServerImpl(k), ctx
+	pk, ctx := keeper.PropertyKeeper(t)
+	ak, _ := keeper.ArdaKeeper(t)
+	return pk, propertykeeper.NewMsgServerImpl(pk, ak), ctx
 }
 
 func TestRegisterPropertyLengthMismatch(t *testing.T) {

--- a/x/property/keeper/msg_server_test.go
+++ b/x/property/keeper/msg_server_test.go
@@ -14,8 +14,9 @@ import (
 )
 
 func setupMsgServer(t testing.TB) (keeper.Keeper, types.MsgServer, context.Context) {
-	k, ctx := keepertest.PropertyKeeper(t)
-	return k, keeper.NewMsgServerImpl(k), ctx
+	pk, ctx := keepertest.PropertyKeeper(t)
+	ak, _ := keepertest.ArdaKeeper(t)
+	return pk, keeper.NewMsgServerImpl(pk, ak), ctx
 }
 
 func TestMsgServer(t *testing.T) {

--- a/x/property/module/module.go
+++ b/x/property/module/module.go
@@ -21,6 +21,7 @@ import (
 	// this line is used by starport scaffolding # 1
 
 	modulev1 "github.com/ardaglobal/arda-poc/api/ardapoc/property/module"
+	ardamodulekeeper "github.com/ardaglobal/arda-poc/x/arda/keeper"
 
 	"github.com/ardaglobal/arda-poc/x/property/keeper"
 
@@ -98,6 +99,7 @@ type AppModule struct {
 	AppModuleBasic
 
 	keeper        keeper.Keeper
+	ardaKeeper    ardamodulekeeper.Keeper
 	accountKeeper types.AccountKeeper
 	bankKeeper    types.BankKeeper
 }
@@ -105,12 +107,14 @@ type AppModule struct {
 func NewAppModule(
 	cdc codec.Codec,
 	keeper keeper.Keeper,
+	ardaKeeper ardamodulekeeper.Keeper,
 	accountKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
 ) AppModule {
 	return AppModule{
 		AppModuleBasic: NewAppModuleBasic(cdc),
 		keeper:         keeper,
+		ardaKeeper:     ardaKeeper,
 		accountKeeper:  accountKeeper,
 		bankKeeper:     bankKeeper,
 	}
@@ -118,7 +122,7 @@ func NewAppModule(
 
 // RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper, am.ardaKeeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
@@ -184,6 +188,7 @@ type ModuleInputs struct {
 
 	AccountKeeper types.AccountKeeper
 	BankKeeper    types.BankKeeper
+	ArdaKeeper    ardamodulekeeper.Keeper
 }
 
 type ModuleOutputs struct {
@@ -208,6 +213,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 	m := NewAppModule(
 		in.Cdc,
 		k,
+		in.ArdaKeeper,
 		in.AccountKeeper,
 		in.BankKeeper,
 	)


### PR DESCRIPTION
## Summary
- hash property & share transfers
- send these hashes to the arda module
- wire arda keeper into property module
- adjust tests for new msg server

## Testing
- `go test ./...` *(fails: no route to host)*