### PR TITLE
Add USDArda module with mint/burn

### DIFF
--- a/testutil/keeper/usdarda.go
+++ b/testutil/keeper/usdarda.go
@@ -1,0 +1,82 @@
+package keeper
+
+import (
+	"context"
+	"testing"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/store"
+	"cosmossdk.io/store/metrics"
+	storetypes "cosmossdk.io/store/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/stretchr/testify/require"
+
+	propertykeeper "github.com/ardaglobal/arda-poc/x/property/keeper"
+	propertytypes "github.com/ardaglobal/arda-poc/x/property/types"
+	usdkeeper "github.com/ardaglobal/arda-poc/x/usdarda/keeper"
+	usdtypes "github.com/ardaglobal/arda-poc/x/usdarda/types"
+)
+
+type MockBankKeeper struct {
+	balances map[string]sdk.Coins
+}
+
+func NewMockBankKeeper() *MockBankKeeper {
+	return &MockBankKeeper{balances: make(map[string]sdk.Coins)}
+}
+
+func (m *MockBankKeeper) MintCoins(ctx context.Context, module string, amt sdk.Coins) error {
+	m.balances[module] = m.balances[module].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) BurnCoins(ctx context.Context, module string, amt sdk.Coins) error {
+	m.balances[module] = m.balances[module].Sub(amt)
+	return nil
+}
+
+func (m *MockBankKeeper) SendCoinsFromModuleToAccount(ctx context.Context, module string, addr sdk.AccAddress, amt sdk.Coins) error {
+	m.balances[module] = m.balances[module].Sub(amt)
+	key := addr.String()
+	m.balances[key] = m.balances[key].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) SendCoinsFromAccountToModule(ctx context.Context, addr sdk.AccAddress, module string, amt sdk.Coins) error {
+	key := addr.String()
+	m.balances[key] = m.balances[key].Sub(amt)
+	m.balances[module] = m.balances[module].Add(amt...)
+	return nil
+}
+
+func UsdArdaKeeper(t testing.TB) (usdkeeper.Keeper, propertykeeper.Keeper, *MockBankKeeper, sdk.Context) {
+	usdKey := storetypes.NewKVStoreKey(usdtypes.StoreKey)
+	propertyKey := storetypes.NewKVStoreKey(propertytypes.StoreKey)
+
+	db := dbm.NewMemDB()
+	ms := store.NewCommitMultiStore(db, log.NewNopLogger(), metrics.NewNoOpMetrics())
+	ms.MountStoreWithDB(usdKey, storetypes.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(propertyKey, storetypes.StoreTypeIAVL, db)
+	require.NoError(t, ms.LoadLatestVersion())
+
+	reg := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(reg)
+	authority := authtypes.NewModuleAddress(govtypes.ModuleName)
+
+	propKeeper := propertykeeper.NewKeeper(cdc, runtime.NewKVStoreService(propertyKey), log.NewNopLogger(), authority.String())
+	bankKeeper := NewMockBankKeeper()
+	k := usdkeeper.NewKeeper(cdc, runtime.NewKVStoreService(usdKey), log.NewNopLogger(), bankKeeper, propKeeper, authority.String())
+
+	ctx := sdk.NewContext(ms, cmtproto.Header{}, false, log.NewNopLogger())
+	require.NoError(t, propKeeper.SetParams(ctx, propertytypes.DefaultParams()))
+	require.NoError(t, k.SetParams(ctx, usdtypes.DefaultParams()))
+
+	return k, propKeeper, bankKeeper, ctx
+}

--- a/x/usdarda/keeper/keeper.go
+++ b/x/usdarda/keeper/keeper.go
@@ -1,0 +1,142 @@
+package keeper
+
+import (
+	"fmt"
+
+	"cosmossdk.io/core/store"
+	"cosmossdk.io/log"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/ardaglobal/arda-poc/x/usdarda/types"
+)
+
+type Keeper struct {
+	cdc          codec.BinaryCodec
+	storeService store.KVStoreService
+	logger       log.Logger
+
+	bankKeeper     types.BankKeeper
+	propertyKeeper types.PropertyKeeper
+
+	authority string
+}
+
+func NewKeeper(
+	cdc codec.BinaryCodec,
+	storeService store.KVStoreService,
+	logger log.Logger,
+	bankKeeper types.BankKeeper,
+	propertyKeeper types.PropertyKeeper,
+	authority string,
+) Keeper {
+	if _, err := sdk.AccAddressFromBech32(authority); err != nil {
+		panic(fmt.Sprintf("invalid authority address: %s", authority))
+	}
+
+	return Keeper{
+		cdc:            cdc,
+		storeService:   storeService,
+		logger:         logger,
+		bankKeeper:     bankKeeper,
+		propertyKeeper: propertyKeeper,
+		authority:      authority,
+	}
+}
+
+func (k Keeper) Logger() log.Logger {
+	return k.logger.With("module", fmt.Sprintf("x/%s", types.ModuleName))
+}
+
+func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
+	store := k.storeService.OpenKVStore(ctx)
+	bz, err := store.Get(types.ParamsKey)
+	if err == nil && bz != nil {
+		k.cdc.MustUnmarshal(bz, &params)
+	}
+	return params
+}
+
+func (k Keeper) SetParams(ctx sdk.Context, params types.Params) error {
+	store := k.storeService.OpenKVStore(ctx)
+	bz, err := k.cdc.Marshal(&params)
+	if err != nil {
+		return err
+	}
+	return store.Set(types.ParamsKey, bz)
+}
+
+func (k Keeper) storeKey(propertyID string) []byte {
+	return append(types.KeyPrefix(types.KeyPrefixUsdArda), []byte(propertyID)...)
+}
+
+func (k Keeper) GetRecord(ctx sdk.Context, propertyID string) (types.UsdArdaRecord, bool) {
+	kv := k.storeService.OpenKVStore(ctx)
+	bz, err := kv.Get(k.storeKey(propertyID))
+	if err != nil || bz == nil {
+		return types.UsdArdaRecord{}, false
+	}
+	var rec types.UsdArdaRecord
+	k.cdc.MustUnmarshal(bz, &rec)
+	return rec, true
+}
+
+func (k Keeper) setRecord(ctx sdk.Context, rec types.UsdArdaRecord) {
+	kv := k.storeService.OpenKVStore(ctx)
+	bz := k.cdc.MustMarshal(&rec)
+	kv.Set(k.storeKey(rec.PropertyId), bz)
+}
+
+func (k Keeper) deleteRecord(ctx sdk.Context, propertyID string) {
+	kv := k.storeService.OpenKVStore(ctx)
+	kv.Delete(k.storeKey(propertyID))
+}
+
+func (k Keeper) Mint(ctx sdk.Context, propertyID string, amount uint64, addr sdk.AccAddress) error {
+	property, found := k.propertyKeeper.GetProperty(ctx, propertyID)
+	if !found {
+		return fmt.Errorf("property %s not found", propertyID)
+	}
+
+	rec, _ := k.GetRecord(ctx, propertyID)
+	max := property.Value * 80 / 100
+	if rec.Minted+amount > max {
+		return fmt.Errorf("mint exceeds 80%% of property value")
+	}
+
+	coin := sdk.NewCoin(types.ModuleName, sdk.NewIntFromUint64(amount))
+	if err := k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(coin)); err != nil {
+		return err
+	}
+	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, addr, sdk.NewCoins(coin)); err != nil {
+		return err
+	}
+
+	rec.PropertyId = propertyID
+	rec.Minted += amount
+	k.setRecord(ctx, rec)
+	return nil
+}
+
+func (k Keeper) Burn(ctx sdk.Context, propertyID string, amount uint64, addr sdk.AccAddress) error {
+	rec, found := k.GetRecord(ctx, propertyID)
+	if !found || rec.Minted < amount {
+		return fmt.Errorf("insufficient minted amount")
+	}
+
+	coin := sdk.NewCoin(types.ModuleName, sdk.NewIntFromUint64(amount))
+	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, addr, types.ModuleName, sdk.NewCoins(coin)); err != nil {
+		return err
+	}
+	if err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(coin)); err != nil {
+		return err
+	}
+
+	rec.Minted -= amount
+	if rec.Minted == 0 {
+		k.deleteRecord(ctx, propertyID)
+	} else {
+		k.setRecord(ctx, rec)
+	}
+	return nil
+}

--- a/x/usdarda/keeper/mint_burn_test.go
+++ b/x/usdarda/keeper/mint_burn_test.go
@@ -1,0 +1,59 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/ardaglobal/arda-poc/testutil/keeper"
+	propertytypes "github.com/ardaglobal/arda-poc/x/property/types"
+)
+
+func setupProperty(t *testing.T, pk propertytypes.PropertyKeeper, ctx sdk.Context) propertytypes.Property {
+	prop := propertytypes.Property{
+		Index:   "prop1",
+		Address: "addr",
+		Region:  "region",
+		Value:   1000,
+		Owners:  []string{"owner"},
+		Shares:  []uint64{100},
+	}
+	pk.SetProperty(ctx, prop)
+	return prop
+}
+
+func TestMintBurnFlows(t *testing.T) {
+	k, propK, _, ctx := keepertest.UsdArdaKeeper(t)
+	prop := setupProperty(t, propK, ctx)
+	addr := sdk.AccAddress([]byte("addr1____________"))
+
+	// mint 80% at once
+	err := k.Mint(ctx, prop.Index, prop.Value*80/100, addr)
+	require.NoError(t, err)
+	rec, found := k.GetRecord(ctx, prop.Index)
+	require.True(t, found)
+	require.Equal(t, uint64(800), rec.Minted)
+
+	// burn all to unlock
+	err = k.Burn(ctx, prop.Index, 800, addr)
+	require.NoError(t, err)
+	_, found = k.GetRecord(ctx, prop.Index)
+	require.False(t, found)
+
+	// multiple mints
+	err = k.Mint(ctx, prop.Index, 300, addr)
+	require.NoError(t, err)
+	err = k.Mint(ctx, prop.Index, 500, addr)
+	require.NoError(t, err)
+	rec, _ = k.GetRecord(ctx, prop.Index)
+	require.Equal(t, uint64(800), rec.Minted)
+
+	// multiple burns
+	err = k.Burn(ctx, prop.Index, 200, addr)
+	require.NoError(t, err)
+	err = k.Burn(ctx, prop.Index, 600, addr)
+	require.NoError(t, err)
+	_, found = k.GetRecord(ctx, prop.Index)
+	require.False(t, found)
+}

--- a/x/usdarda/types/expected_keepers.go
+++ b/x/usdarda/types/expected_keepers.go
@@ -1,0 +1,23 @@
+package types
+
+import (
+	"context"
+
+	propertytypes "github.com/ardaglobal/arda-poc/x/property/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type AccountKeeper interface {
+	GetAccount(context.Context, sdk.AccAddress) sdk.AccountI
+}
+
+type BankKeeper interface {
+	MintCoins(ctx context.Context, module string, amt sdk.Coins) error
+	BurnCoins(ctx context.Context, module string, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+}
+
+type PropertyKeeper interface {
+	GetProperty(ctx sdk.Context, id string) (propertytypes.Property, bool)
+}

--- a/x/usdarda/types/genesis.go
+++ b/x/usdarda/types/genesis.go
@@ -1,0 +1,13 @@
+package types
+
+const DefaultIndex uint64 = 1
+
+func DefaultGenesis() *GenesisState {
+	return &GenesisState{
+		Params: DefaultParams(),
+	}
+}
+
+func (gs GenesisState) Validate() error {
+	return gs.Params.Validate()
+}

--- a/x/usdarda/types/keys.go
+++ b/x/usdarda/types/keys.go
@@ -1,0 +1,17 @@
+package types
+
+const (
+	ModuleName  = "usdarda"
+	StoreKey    = ModuleName
+	MemStoreKey = "mem_usdarda"
+
+	KeyPrefixUsdArda = "UsdArda/value/"
+)
+
+var (
+	ParamsKey = []byte("p_usdarda")
+)
+
+func KeyPrefix(p string) []byte {
+	return []byte(p)
+}

--- a/x/usdarda/types/params.go
+++ b/x/usdarda/types/params.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+)
+
+var _ paramtypes.ParamSet = (*Params)(nil)
+
+func ParamKeyTable() paramtypes.KeyTable {
+	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
+}
+
+func NewParams() Params {
+	return Params{}
+}
+
+func DefaultParams() Params {
+	return NewParams()
+}
+
+func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
+	return paramtypes.ParamSetPairs{}
+}
+
+func (p Params) Validate() error { return nil }

--- a/x/usdarda/types/usdarda.go
+++ b/x/usdarda/types/usdarda.go
@@ -1,0 +1,6 @@
+package types
+
+type UsdArdaRecord struct {
+	PropertyId string
+	Minted     uint64
+}


### PR DESCRIPTION
## Summary
- scaffold a basic `usdarda` module
- implement keeper with `Mint` and `Burn` methods that lock properties and mint 80% of value
- add a mock bank keeper for tests
- add tests demonstrating mint/burn flows

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*