### PR TITLE
Integrate property shares with bank module

### DIFF
--- a/app/app_config.go
+++ b/app/app_config.go
@@ -165,6 +165,7 @@ var (
 		{Account: ibctransfertypes.ModuleName, Permissions: []string{authtypes.Minter, authtypes.Burner}},
 		{Account: ibcfeetypes.ModuleName},
 		{Account: icatypes.ModuleName},
+		{Account: propertymoduletypes.ModuleName, Permissions: []string{authtypes.Minter}},
 		// this line is used by starport scaffolding # stargate/app/maccPerms
 	}
 

--- a/testutil/keeper/property.go
+++ b/testutil/keeper/property.go
@@ -54,6 +54,7 @@ func PropertyKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
 }
 
 // BankKeeperMock implements types.BankKeeper for tests.
+// TODO: how can we remove this mock? What is the right way to handle this?
 type BankKeeperMock struct{}
 
 func (BankKeeperMock) SpendableCoins(ctx context.Context, addr sdk.AccAddress) sdk.Coins {

--- a/testutil/keeper/property.go
+++ b/testutil/keeper/property.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"context"
 	"testing"
 
 	"cosmossdk.io/log"
@@ -33,10 +34,12 @@ func PropertyKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
 	cdc := codec.NewProtoCodec(registry)
 	authority := authtypes.NewModuleAddress(govtypes.ModuleName)
 
+	bk := BankKeeperMock{}
 	k := keeper.NewKeeper(
 		cdc,
 		runtime.NewKVStoreService(storeKey),
 		log.NewNopLogger(),
+		bk,
 		authority.String(),
 	)
 
@@ -48,4 +51,21 @@ func PropertyKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
 	}
 
 	return k, ctx
+}
+
+// BankKeeperMock implements types.BankKeeper for tests.
+type BankKeeperMock struct{}
+
+func (BankKeeperMock) SpendableCoins(ctx context.Context, addr sdk.AccAddress) sdk.Coins {
+	return sdk.Coins{}
+}
+func (BankKeeperMock) MintCoins(ctx context.Context, module string, amt sdk.Coins) error { return nil }
+func (BankKeeperMock) SendCoinsFromModuleToAccount(ctx context.Context, sender string, recipient sdk.AccAddress, amt sdk.Coins) error {
+	return nil
+}
+func (BankKeeperMock) SendCoinsFromAccountToModule(ctx context.Context, sender sdk.AccAddress, recipient string, amt sdk.Coins) error {
+	return nil
+}
+func (BankKeeperMock) SendCoins(ctx context.Context, from sdk.AccAddress, to sdk.AccAddress, amt sdk.Coins) error {
+	return nil
 }

--- a/x/property/keeper/keeper.go
+++ b/x/property/keeper/keeper.go
@@ -17,6 +17,8 @@ type (
 		storeService store.KVStoreService
 		logger       log.Logger
 
+		bankKeeper types.BankKeeper
+
 		// the address capable of executing a MsgUpdateParams message. Typically, this
 		// should be the x/gov module account.
 		authority string
@@ -27,6 +29,7 @@ func NewKeeper(
 	cdc codec.BinaryCodec,
 	storeService store.KVStoreService,
 	logger log.Logger,
+	bankKeeper types.BankKeeper,
 	authority string,
 
 ) Keeper {
@@ -39,6 +42,7 @@ func NewKeeper(
 		storeService: storeService,
 		authority:    authority,
 		logger:       logger,
+		bankKeeper:   bankKeeper,
 	}
 }
 
@@ -75,29 +79,28 @@ func (k Keeper) GetProperty(ctx sdk.Context, id string) (types.Property, bool) {
 
 // ConvertPropertyOwnersToMap converts the owners and shares slices in a property to a map
 func (k Keeper) ConvertPropertyOwnersToMap(property types.Property) map[string]uint64 {
-    ownerMap := make(map[string]uint64)
-    for i, owner := range property.Owners {
-        if i >= len(property.Shares) {
+	ownerMap := make(map[string]uint64)
+	for i, owner := range property.Owners {
+		if i >= len(property.Shares) {
 			panic(fmt.Sprintf("property %s has more owners than shares", property.Index))
-        }
-        ownerMap[owner] = property.Shares[i]
-    }
-    return ownerMap
+		}
+		ownerMap[owner] = property.Shares[i]
+	}
+	return ownerMap
 }
 
 // UpdatePropertyFromOwnerMap updates a property's owners and shares slices from a map
 func (k Keeper) UpdatePropertyFromOwnerMap(property *types.Property, ownerMap map[string]uint64) {
-    // Clear existing slices
-    property.Owners = make([]string, 0, len(ownerMap))
-    property.Shares = make([]uint64, 0, len(ownerMap))
+	// Clear existing slices
+	property.Owners = make([]string, 0, len(ownerMap))
+	property.Shares = make([]uint64, 0, len(ownerMap))
 
-    // Convert map back to slices
-    for owner, shares := range ownerMap {
-        property.Owners = append(property.Owners, owner)
-        property.Shares = append(property.Shares, shares)
-    }
+	// Convert map back to slices
+	for owner, shares := range ownerMap {
+		property.Owners = append(property.Owners, owner)
+		property.Shares = append(property.Shares, shares)
+	}
 }
-
 
 func (k Keeper) SetProperty(ctx sdk.Context, property types.Property) {
 	kvStore := k.storeService.OpenKVStore(ctx)

--- a/x/property/keeper/msg_server.go
+++ b/x/property/keeper/msg_server.go
@@ -8,12 +8,13 @@ import (
 type msgServer struct {
 	Keeper
 	ardaKeeper ardamodulekeeper.Keeper
+	bankKeeper types.BankKeeper
 }
 
 // NewMsgServerImpl returns an implementation of the MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper Keeper, ardaKeeper ardamodulekeeper.Keeper) types.MsgServer {
-	return &msgServer{Keeper: keeper, ardaKeeper: ardaKeeper}
+func NewMsgServerImpl(keeper Keeper, ardaKeeper ardamodulekeeper.Keeper, bankKeeper types.BankKeeper) types.MsgServer {
+	return &msgServer{Keeper: keeper, ardaKeeper: ardaKeeper, bankKeeper: bankKeeper}
 }
 
 var _ types.MsgServer = msgServer{}

--- a/x/property/keeper/msg_server_register_property_test.go
+++ b/x/property/keeper/msg_server_register_property_test.go
@@ -15,7 +15,8 @@ import (
 func setupMsgServerRegister(t testing.TB) (propertykeeper.Keeper, types.MsgServer, context.Context) {
 	pk, ctx := keeper.PropertyKeeper(t)
 	ak, _ := keeper.ArdaKeeper(t)
-	return pk, propertykeeper.NewMsgServerImpl(pk, ak), ctx
+	bk := keeper.BankKeeperMock{}
+	return pk, propertykeeper.NewMsgServerImpl(pk, ak, bk), ctx
 }
 
 func TestRegisterPropertyLengthMismatch(t *testing.T) {

--- a/x/property/keeper/msg_server_test.go
+++ b/x/property/keeper/msg_server_test.go
@@ -16,7 +16,8 @@ import (
 func setupMsgServer(t testing.TB) (keeper.Keeper, types.MsgServer, context.Context) {
 	pk, ctx := keepertest.PropertyKeeper(t)
 	ak, _ := keepertest.ArdaKeeper(t)
-	return pk, keeper.NewMsgServerImpl(pk, ak), ctx
+	bk := keepertest.BankKeeperMock{}
+	return pk, keeper.NewMsgServerImpl(pk, ak, bk), ctx
 }
 
 func TestMsgServer(t *testing.T) {

--- a/x/property/module/autocli.go
+++ b/x/property/module/autocli.go
@@ -2,6 +2,7 @@ package property
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
@@ -11,6 +12,7 @@ import (
 
 	modulev1 "github.com/ardaglobal/arda-poc/api/ardapoc/property"
 	"github.com/ardaglobal/arda-poc/x/property/types"
+	"github.com/cosmos/cosmos-sdk/client/tx"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
@@ -184,4 +186,139 @@ func printProperty(prop *types.Property) {
 		fmt.Printf("    - From: %s; To: %s; Timestamp: %s\n",
 			transfer.From, transfer.To, transfer.Timestamp)
 	}
+}
+
+// GetTxCmd returns the custom-formatted property transaction commands
+func (AppModuleBasic) GetTxCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        "property",
+		Short:                      "Transaction commands for the property module",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		GetCmdRegisterProperty(),
+		GetCmdTransferShares(),
+	)
+
+	return cmd
+}
+
+// GetCmdRegisterProperty implements a custom-formatted register-property command
+func GetCmdRegisterProperty() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "register-property [address] [region] [value]",
+		Short: "Register a new property with address, region, and value",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			// Parse value as uint64
+			value, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid value: %s", err)
+			}
+
+			// Get owners and shares from flags
+			owners, err := cmd.Flags().GetStringSlice("owners")
+			if err != nil {
+				return err
+			}
+
+			sharesStr, err := cmd.Flags().GetStringSlice("shares")
+			if err != nil {
+				return err
+			}
+
+			// Convert shares to uint64
+			shares := make([]uint64, len(sharesStr))
+			for i, share := range sharesStr {
+				shareUint, err := strconv.ParseUint(share, 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid share value at position %d: %s", i, err)
+				}
+				shares[i] = shareUint
+			}
+
+			// Validate owners and shares have same length
+			if len(owners) != len(shares) {
+				return fmt.Errorf("number of owners (%d) must match number of shares (%d)", len(owners), len(shares))
+			}
+
+			msg := types.NewMsgRegisterProperty(
+				clientCtx.GetFromAddress().String(),
+				strings.TrimSpace(args[0]), // address
+				strings.TrimSpace(args[1]), // region
+				value,
+				owners,
+				shares,
+			)
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().StringSlice("owners", []string{}, "Comma-separated list of property owners")
+	cmd.Flags().StringSlice("shares", []string{}, "Comma-separated list of shares (must match number of owners)")
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// GetCmdTransferShares implements a custom-formatted transfer-shares command
+func GetCmdTransferShares() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "transfer-shares [property-id] [from-owners] [from-shares] [to-owners] [to-shares]",
+		Short: "Transfer property shares between owners",
+		Args:  cobra.ExactArgs(5),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			// Parse from-owners and from-shares as arrays
+			fromOwners := strings.Split(args[1], ",")
+			fromShares := strings.Split(args[2], ",")
+			toOwners := strings.Split(args[3], ",")
+			toShares := strings.Split(args[4], ",")
+
+			// Convert share strings to uint64 slices
+			fromSharesUint := make([]uint64, len(fromShares))
+			for i, share := range fromShares {
+				shareUint, err := strconv.ParseUint(share, 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid from-share value at position %d: %s", i, err)
+				}
+				fromSharesUint[i] = shareUint
+			}
+
+			toSharesUint := make([]uint64, len(toShares))
+			for i, share := range toShares {
+				shareUint, err := strconv.ParseUint(share, 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid to-share value at position %d: %s", i, err)
+				}
+				toSharesUint[i] = shareUint
+			}
+
+			msg := types.NewMsgTransferShares(
+				clientCtx.GetFromAddress().String(),
+				strings.TrimSpace(args[0]), // property-id
+				fromOwners,
+				fromSharesUint,
+				toOwners,
+				toSharesUint,
+			)
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
 }

--- a/x/property/module/module.go
+++ b/x/property/module/module.go
@@ -122,7 +122,7 @@ func NewAppModule(
 
 // RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper, am.ardaKeeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper, am.ardaKeeper, am.bankKeeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
@@ -208,6 +208,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.Cdc,
 		in.StoreService,
 		in.Logger,
+		in.BankKeeper,
 		authority.String(),
 	)
 	m := NewAppModule(

--- a/x/property/types/expected_keepers.go
+++ b/x/property/types/expected_keepers.go
@@ -15,7 +15,10 @@ type AccountKeeper interface {
 // BankKeeper defines the expected interface for the Bank module.
 type BankKeeper interface {
 	SpendableCoins(context.Context, sdk.AccAddress) sdk.Coins
-	// Methods imported from bank should be defined here
+	MintCoins(context.Context, string, sdk.Coins) error
+	SendCoinsFromModuleToAccount(context.Context, string, sdk.AccAddress, sdk.Coins) error
+	SendCoinsFromAccountToModule(context.Context, sdk.AccAddress, string, sdk.Coins) error
+	SendCoins(context.Context, sdk.AccAddress, sdk.AccAddress, sdk.Coins) error
 }
 
 // ParamSubspace defines the expected Subspace interface for parameters.

--- a/x/property/types/keys.go
+++ b/x/property/types/keys.go
@@ -26,6 +26,7 @@ func KeyPrefix(p string) []byte {
 }
 
 // PropertyShareDenom returns the bank denom used for the given property ID.
-func PropertyShareDenom(id string) string {
-	return PropertyShareDenomPrefix + id
+func PropertyShareDenom(_ string) string {
+	// return PropertyShareDenomPrefix + id
+	return PropertyShareDenomPrefix
 }

--- a/x/property/types/keys.go
+++ b/x/property/types/keys.go
@@ -12,6 +12,9 @@ const (
 
 	// KeyPrefixProperty is the prefix used to store properties by ID
 	KeyPrefixProperty = "Property/value/"
+
+	// PropertyShareDenomPrefix defines the prefix for property share denoms
+	PropertyShareDenomPrefix = "property_"
 )
 
 var (
@@ -20,4 +23,9 @@ var (
 
 func KeyPrefix(p string) []byte {
 	return []byte(p)
+}
+
+// PropertyShareDenom returns the bank denom used for the given property ID.
+func PropertyShareDenom(id string) string {
+	return PropertyShareDenomPrefix + id
 }


### PR DESCRIPTION
## Summary
- extend property `BankKeeper` interface with coin management helpers
- add bank keeper to property keeper and msg server
- mint share tokens on property registration
- move share tokens on transfer
- provide property bank keeper via DI and module account config
- add test helpers for bank keeper

## TODO
- [x] fix double counting in transfers (see charlie after transfer, 120? )
- [x] fix transfer cli print out for names/addresses

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Property share tokens are minted and distributed to owners upon property registration.
  - Property share tokens are transferred between accounts when property shares change hands.
  - Added CLI commands for registering properties and transferring property shares with enhanced user-friendly address/name handling.
- **Enhancements**
  - Integrated banking module permissions to support minting and token transfers.
  - Improved query output to display human-readable owner and transfer participant names.
- **Tests**
  - Updated test utilities and setups to include mock banking functionalities and dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->