### PR TITLE
feat: Lazy load validator key

### DIFF
--- a/x/arda/keeper/msg_server_submit_hash.go
+++ b/x/arda/keeper/msg_server_submit_hash.go
@@ -16,11 +16,12 @@ import (
 func (k Keeper) SubmitHash(goCtx context.Context, msg *types.MsgSubmitHash) (*types.MsgSubmitHashResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	// 1. Get the pubkey for the region
-	pubKeyBase64, ok := regionPubKeys[msg.Region]
-	if !ok {
-		return nil, errors.New("region not recognized")
+	// 1. Get the pubkey for the region. Load it if it hasn't been loaded yet.
+	pubKeyBase64, err := getRegionPubKey(msg.Region)
+	if err != nil {
+		return nil, err
 	}
+
 	pubKeyBytes, err := base64.StdEncoding.DecodeString(pubKeyBase64)
 	if err != nil {
 		return nil, errors.New("error decoding pubkey")


### PR DESCRIPTION
## Summary
- lazily load validator key instead of at package init
- fetch public key when `SubmitHash` is called

## Testing
- `go test ./...` *(fails: no network access to download Go toolchain)*