### PR TITLE
feat: Add development environment setup script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,15 +111,22 @@ lint-fix:
 # protobuf generators, Ignite CLI and linters.
 
 ignite-version=v28.10.0
+go-version=$(shell go list -m -f '{{.GoVersion}}')
 
-setup-dev: proto-deps
-	@echo "--> Installing Ignite CLI"
-	@curl https://get.ignite.com/cli@$(ignite-version)! | bash
+setup-script:
+	@echo "--> Making setup script executable"
+	@chmod +x scripts/setup_dev_env.sh
+	@echo "--> Running setup script"
+	@IGNITE_VERSION=$(ignite-version) GO_VERSION=$(go-version) ./scripts/setup_dev_env.sh
+.PHONY: setup-script
+
+
+setup-dev: setup-script proto-deps
 	@echo "--> Installing lint and security tools"
 	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golangci_version)
 	@go install golang.org/x/vuln/cmd/govulncheck@latest
 	@go install golang.org/x/tools/cmd/goimports@latest
-
+.PHONY: setup-dev
 
 ###################
 ### Development ###

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,17 @@ This runs `ignite chain serve` with the `config.yml` file.
 
 You can use https://github.com/ardaglobal/dexplorer to view the blockchain on the arda branch.
 
+### Setup Development Environment
+
+Run the `scripts/setup_dev_env.sh` script to install Go, Docker, Ignite CLI and
+other tooling required for development. The script ensures all dependencies are
+present and then executes `make setup-dev` to install additional Go tools and
+protoc generators.
+
+```
+./scripts/setup_dev_env.sh
+```
+
 ### Functionality
 
 

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -8,10 +8,11 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
+# These versions can be overridden by setting environment variables when running the script:
+# IGNITE_VERSION=v28.11.0 GO_VERSION=1.24.1 ./scripts/setup_dev_env.sh
 
-IGNITE_VERSION="v28.10.0"
-GOLANGCI_VERSION="v1.61.0"
-GO_VERSION="1.24.0"
+IGNITE_VERSION="${IGNITE_VERSION:-v28.10.0}"
+GO_VERSION="${GO_VERSION:-1.24.0}"
 
 # Determine repository root and switch to it
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -63,7 +64,5 @@ else
 fi
 
 # Install additional Go tools and proto deps via Makefile
-echo -e "${BLUE}Installing remaining development tools via make setup-dev${NC}"
-make setup-dev
 
 echo -e "${GREEN}Development environment setup complete!${NC}"

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+IGNITE_VERSION="v28.10.0"
+GOLANGCI_VERSION="v1.61.0"
+GO_VERSION="1.24.0"
+
+# Determine repository root and switch to it
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+cd "$REPO_ROOT"
+
+check_cmd() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+install_go() {
+    echo -e "${BLUE}Installing Go ${GO_VERSION}${NC}"
+    curl -sL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz
+    sudo rm -rf /usr/local/go
+    sudo tar -C /usr/local -xzf /tmp/go.tar.gz
+    rm /tmp/go.tar.gz
+    export PATH=/usr/local/go/bin:$PATH
+}
+
+install_docker() {
+    echo -e "${BLUE}Installing Docker${NC}"
+    curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+    sudo sh /tmp/get-docker.sh
+    rm /tmp/get-docker.sh
+}
+
+install_ignite() {
+    echo -e "${BLUE}Installing Ignite CLI ${IGNITE_VERSION}${NC}"
+    curl https://get.ignite.com/cli@${IGNITE_VERSION}! | bash
+}
+
+# Ensure required tools
+if ! check_cmd go; then
+    install_go
+else
+    echo -e "${GREEN}Go detected:${NC} $(go version)"
+fi
+
+if ! check_cmd docker; then
+    install_docker
+else
+    echo -e "${GREEN}Docker detected:${NC} $(docker --version)"
+fi
+
+if ! check_cmd ignite; then
+    install_ignite
+else
+    echo -e "${GREEN}Ignite detected:${NC} $(ignite version)"
+fi
+
+# Install additional Go tools and proto deps via Makefile
+echo -e "${BLUE}Installing remaining development tools via make setup-dev${NC}"
+make setup-dev
+
+echo -e "${GREEN}Development environment setup complete!${NC}"


### PR DESCRIPTION
## Summary
- add `scripts/setup_dev_env.sh` to install tooling and run `make setup-dev`
- document how to use the new script in `readme.md`

## Testing
- `make test` *(fails: no route to host for Go toolchain)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated script to set up the development environment, installing required tools such as Go, Docker, and Ignite CLI.
- **Documentation**
  - Added a new section to the README with instructions on running the setup script and preparing the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->