### PR TITLE
link USDArda mint/burn on property actions

### DIFF
--- a/x/property/keeper/msg_server.go
+++ b/x/property/keeper/msg_server.go
@@ -3,18 +3,20 @@ package keeper
 import (
 	ardamodulekeeper "github.com/ardaglobal/arda-poc/x/arda/keeper"
 	"github.com/ardaglobal/arda-poc/x/property/types"
+	usdkeeper "github.com/ardaglobal/arda-poc/x/usdarda/keeper"
 )
 
 type msgServer struct {
 	Keeper
 	ardaKeeper ardamodulekeeper.Keeper
 	bankKeeper types.BankKeeper
+	usdKeeper  usdkeeper.Keeper
 }
 
 // NewMsgServerImpl returns an implementation of the MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper Keeper, ardaKeeper ardamodulekeeper.Keeper, bankKeeper types.BankKeeper) types.MsgServer {
-	return &msgServer{Keeper: keeper, ardaKeeper: ardaKeeper, bankKeeper: bankKeeper}
+func NewMsgServerImpl(keeper Keeper, ardaKeeper ardamodulekeeper.Keeper, bankKeeper types.BankKeeper, usdKeeper usdkeeper.Keeper) types.MsgServer {
+	return &msgServer{Keeper: keeper, ardaKeeper: ardaKeeper, bankKeeper: bankKeeper, usdKeeper: usdKeeper}
 }
 
 var _ types.MsgServer = msgServer{}

--- a/x/property/keeper/msg_server_register_property.go
+++ b/x/property/keeper/msg_server_register_property.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ardaglobal/arda-poc/pkg/utils"
 	ardatypes "github.com/ardaglobal/arda-poc/x/arda/types"
 	"github.com/ardaglobal/arda-poc/x/property/types"
+	usdkeeper "github.com/ardaglobal/arda-poc/x/usdarda/keeper"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -99,6 +100,11 @@ func (k msgServer) RegisterProperty(goCtx context.Context, msg *types.MsgRegiste
 			return nil, err
 		}
 		if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, addr, sdk.NewCoins(coin)); err != nil {
+			return nil, err
+		}
+		// Mint equivalent USDArda to owner based on property value and ownership share
+		usdAmount := msg.Value * share / 100
+		if err := k.usdKeeper.Mint(ctx, id, usdAmount, addr); err != nil {
 			return nil, err
 		}
 	}

--- a/x/property/keeper/msg_server_register_property_test.go
+++ b/x/property/keeper/msg_server_register_property_test.go
@@ -13,10 +13,9 @@ import (
 )
 
 func setupMsgServerRegister(t testing.TB) (propertykeeper.Keeper, types.MsgServer, context.Context) {
-	pk, ctx := keeper.PropertyKeeper(t)
+	usdK, pk, bk, ctx := keeper.UsdArdaKeeper(t)
 	ak, _ := keeper.ArdaKeeper(t)
-	bk := keeper.BankKeeperMock{}
-	return pk, propertykeeper.NewMsgServerImpl(pk, ak, bk), ctx
+	return pk, propertykeeper.NewMsgServerImpl(pk, ak, bk, usdK), ctx
 }
 
 func TestRegisterPropertyLengthMismatch(t *testing.T) {

--- a/x/property/keeper/msg_server_test.go
+++ b/x/property/keeper/msg_server_test.go
@@ -14,10 +14,9 @@ import (
 )
 
 func setupMsgServer(t testing.TB) (keeper.Keeper, types.MsgServer, context.Context) {
-	pk, ctx := keepertest.PropertyKeeper(t)
+	usdK, pk, bk, ctx := keepertest.UsdArdaKeeper(t)
 	ak, _ := keepertest.ArdaKeeper(t)
-	bk := keepertest.BankKeeperMock{}
-	return pk, keeper.NewMsgServerImpl(pk, ak, bk), ctx
+	return pk, keeper.NewMsgServerImpl(pk, ak, bk, usdK), ctx
 }
 
 func TestMsgServer(t *testing.T) {

--- a/x/property/module/module.go
+++ b/x/property/module/module.go
@@ -22,6 +22,7 @@ import (
 
 	modulev1 "github.com/ardaglobal/arda-poc/api/ardapoc/property/module"
 	ardamodulekeeper "github.com/ardaglobal/arda-poc/x/arda/keeper"
+	usdkeeper "github.com/ardaglobal/arda-poc/x/usdarda/keeper"
 
 	"github.com/ardaglobal/arda-poc/x/property/keeper"
 
@@ -100,6 +101,7 @@ type AppModule struct {
 
 	keeper        keeper.Keeper
 	ardaKeeper    ardamodulekeeper.Keeper
+	usdKeeper     usdkeeper.Keeper
 	accountKeeper types.AccountKeeper
 	bankKeeper    types.BankKeeper
 }
@@ -108,6 +110,7 @@ func NewAppModule(
 	cdc codec.Codec,
 	keeper keeper.Keeper,
 	ardaKeeper ardamodulekeeper.Keeper,
+	usdKeeper usdkeeper.Keeper,
 	accountKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
 ) AppModule {
@@ -115,6 +118,7 @@ func NewAppModule(
 		AppModuleBasic: NewAppModuleBasic(cdc),
 		keeper:         keeper,
 		ardaKeeper:     ardaKeeper,
+		usdKeeper:      usdKeeper,
 		accountKeeper:  accountKeeper,
 		bankKeeper:     bankKeeper,
 	}
@@ -122,7 +126,7 @@ func NewAppModule(
 
 // RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper, am.ardaKeeper, am.bankKeeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper, am.ardaKeeper, am.bankKeeper, am.usdKeeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
@@ -211,10 +215,19 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.BankKeeper,
 		authority.String(),
 	)
+	usdK := usdkeeper.NewKeeper(
+		in.Cdc,
+		in.StoreService,
+		in.Logger,
+		in.BankKeeper,
+		k,
+		authority.String(),
+	)
 	m := NewAppModule(
 		in.Cdc,
 		k,
 		in.ArdaKeeper,
+		usdK,
 		in.AccountKeeper,
 		in.BankKeeper,
 	)


### PR DESCRIPTION
## Summary
- wire USDArda keeper into property module
- mint USDArda when registering property
- burn and mint USDArda when transferring shares
- update tests for new msg server constructor

## Testing
- `make lint` *(fails: no route to host for golangci-lint)*
- `make test` *(fails: proxyconnect tcp: no route to host)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Property owners now receive USDArda tokens proportional to their property shares during property registration.
  - When property shares are transferred, corresponding USDArda tokens are automatically burned from the sender and minted to the recipient, ensuring token balances reflect share ownership changes.

- **Bug Fixes**
  - None.

- **Tests**
  - Updated test setups to support and validate the new USDArda token minting and burning functionality during property registration and share transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->