### PR TITLE
Fix key path and transfer shares error message

### DIFF
--- a/pkg/utils/hash.go
+++ b/pkg/utils/hash.go
@@ -8,9 +8,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
-const DefaultKeyFile = "/Users/matt/.arda-poc/config/priv_validator_key.json"
+var DefaultKeyFile = defaultKeyFile()
+
+func defaultKeyFile() string {
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".arda-poc", "config", "priv_validator_key.json")
+	}
+	// fallback to relative path
+	return filepath.Join(".arda-poc", "config", "priv_validator_key.json")
+}
 
 type KeyJSON struct {
 	PrivKey struct {

--- a/x/property/keeper/msg_server_transfer_shares.go
+++ b/x/property/keeper/msg_server_transfer_shares.go
@@ -51,7 +51,7 @@ func (k msgServer) TransferShares(goCtx context.Context, msg *types.MsgTransferS
 	}
 
 	if totalFrom != totalTo {
-		return nil, fmt.Errorf("total shares out (%d) must match shares in (%d)", totalTo, totalFrom)
+		return nil, fmt.Errorf("total shares out (%d) must match shares in (%d)", totalFrom, totalTo)
 	}
 
 	ownerMap := k.ConvertPropertyOwnersToMap(property)


### PR DESCRIPTION
## Summary
- use `$HOME/.arda-poc/config/priv_validator_key.json` as the default key location
- fix misordered values in share transfer error message

## Testing
- `go vet ./...` *(fails: Forbidden module downloads)*

------
https://chatgpt.com/codex/tasks/task_e_6846f688a0fc8331b8547db9eb78c697