### PR TITLE
Enable sidecar hot reload

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,24 @@
+# Configuration for Air live reloading
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  cmd = "go build -o ./tmp/tx-sidecar ./cmd/tx-sidecar"
+  bin = "tmp/tx-sidecar"
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  exclude_dir = ["tmp", "vendor", "cmd/tx-sidecar/docs"]
+  exclude_regex = ["_test.go"]
+  follow_symlink = true
+  delay = 1000
+
+[log]
+  time = true
+
+[color]
+  main = "magenta"
+  watcher = "cyan"
+  build = "yellow"
+  runner = "green"
+
+[misc]
+  clean_on_exit = true

--- a/.air.toml
+++ b/.air.toml
@@ -6,10 +6,9 @@ tmp_dir = "tmp"
   cmd = "go build -o ./tmp/tx-sidecar ./cmd/tx-sidecar"
   bin = "tmp/tx-sidecar"
   include_ext = ["go", "tpl", "tmpl", "html"]
-  exclude_dir = ["tmp", "vendor", "cmd/tx-sidecar/docs"]
+  include_dir = ["cmd/tx-sidecar"]
+  exclude_dir = ["tmp", "vendor", "cmd/tx-sidecar/docs", "cmd/tx-sidecar/local_data"]
   exclude_regex = ["_test.go"]
-  follow_symlink = true
-  delay = 1000
 
 [log]
   time = true

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ setup-dev: setup-script proto-deps
 	@go install golang.org/x/vuln/cmd/govulncheck@latest
 	@go install golang.org/x/tools/cmd/goimports@latest
 	@go install github.com/swaggo/swag/cmd/swag@latest
+	@go install github.com/air-verse/air@latest
 .PHONY: setup-dev
 
 ###################
@@ -139,9 +140,9 @@ dev:
 	@ignite chain serve 
 .PHONY: dev
 
-dev-sidecar: sidecar-docs
-       @echo "--> Running dev-sidecar with Air hot reload"
-       @air -c .air.toml
+dev-sidecar:
+	@echo "--> Running dev-sidecar with Air hot reload"
+	@air -c .air.toml
 .PHONY: dev-sidecar
 
 sidecar-docs:

--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,8 @@ dev:
 .PHONY: dev
 
 dev-sidecar: sidecar-docs
-	@echo "--> Running dev-sidecar"
-	@go run ./cmd/tx-sidecar
+       @echo "--> Running dev-sidecar with Air hot reload"
+       @air -c .air.toml
 .PHONY: dev-sidecar
 
 sidecar-docs:

--- a/cmd/tx-sidecar/README.md
+++ b/cmd/tx-sidecar/README.md
@@ -20,8 +20,18 @@ Ensure your `ard-pocd` node is running first. Then, from the root of the `arda-p
 
 ```bash
 make dev-sidecar
-# Or alternatively:
-# go run ./cmd/tx-sidecar/main.go
+```
+This command uses [Air](https://github.com/cosmtrek/air) to watch the
+`cmd/tx-sidecar` sources and automatically rebuild and restart the server when
+files change. Make sure Air is installed:
+
+```bash
+go install github.com/cosmtrek/air@latest
+```
+
+Alternatively you can run:
+```bash
+go run ./cmd/tx-sidecar/main.go
 ```
 The service will start and listen on port `8080`.
 

--- a/cmd/tx-sidecar/README.md
+++ b/cmd/tx-sidecar/README.md
@@ -21,12 +21,12 @@ Ensure your `ard-pocd` node is running first. Then, from the root of the `arda-p
 ```bash
 make dev-sidecar
 ```
-This command uses [Air](https://github.com/cosmtrek/air) to watch the
+This command uses [Air](https://github.com/air-verse/air) to watch the
 `cmd/tx-sidecar` sources and automatically rebuild and restart the server when
 files change. Make sure Air is installed:
 
 ```bash
-go install github.com/cosmtrek/air@latest
+go install github.com/air-verse/air@latest
 ```
 
 Alternatively you can run:


### PR DESCRIPTION
Closes #52 

## Summary
- add Air config for live reload
- use Air in `make dev-sidecar`
- document Air usage in sidecar README
- remove old watcher script

## Testing
- `go test ./...` *(fails: invalid reference to runtime.lastmoduledatap)*

------
https://chatgpt.com/codex/tasks/task_e_684b8083be108331a3cc5188e2d411bb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Chores**
	- Introduced Air live reloading tool configuration for streamlined development workflow.
	- Updated development command to use Air for automatic rebuilds and restarts.
- **Documentation**
	- Enhanced README with instructions for using Air and clarified development workflow steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->